### PR TITLE
hotfix: resolve double type in parser

### DIFF
--- a/src/Parser/ParserValueTypes.hs
+++ b/src/Parser/ParserValueTypes.hs
@@ -7,7 +7,7 @@ import           AST
 import           Parser.LexerParser
 
 import           Text.Parsec        (char, digit, letter, many, many1, noneOf,
-                                     sepBy, (<|>))
+                                     sepBy, (<|>), try)
 import           Text.Parsec.String (Parser)
 
 -- Parse Identifier
@@ -24,8 +24,8 @@ parseUnderscoreLetter =
 -- Parse Literals
 parseLiteral :: Parser Literal
 parseLiteral =
-  parseIntLiteral
-    <|> parseDoubleLiteral
+  (try parseDoubleLiteral) 
+    <|> (try parseIntLiteral)
     <|> parseBoolLiteral
     <|> parseStringLiteral
 


### PR DESCRIPTION
## Description

This **PR** is on charge of fixing `parseLiteral` function which does not parse at all double type.

## Type of Change

Put an `x` in all the boxes that apply:

- [ ] ✨ New Feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug Fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking Change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code Refactor
- [ ] ✅ Build Configuration Change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Pull Request Checklist

Put an `x` in all the boxes that apply:

- [x] My commit messages are detailed.
- [x] My code follows the code style of this project.
- [ ] No existing features have been broken without good reason.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.